### PR TITLE
Start showing multiple columns at 3 columns, instead of 2

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -160,8 +160,8 @@ footer a {
     }
 }
 
-/* Big screens: Points displayed in multiple columns */
-@media only screen and (min-width : 100em) {
+/* Giant screens: Points displayed in multiple (3+) columns */
+@media only screen and (min-width : 140em) {
     div.points {
         display: flex;
         flex-wrap: wrap;


### PR DESCRIPTION
With apologies to information-density geeks, the page just looks
better with a single column.
The multi-column display can still useful for a big, static (not
scrollable) screen, for example at a conference, but then there
should be 3 or 4 columns. If there's space only for two,
let's not overload the reader, and show the points one by one.
