### PR TITLE
update deprecated venv syntax

### DIFF
--- a/points.yml
+++ b/points.yml
@@ -4,7 +4,7 @@
     It is ready for use straight out of the box.  No guessing package names, no installation, just dive in and go.
     Look:
 
-        [fedora]$ pyvenv env
+        [fedora]$ python3 -m venv env
         [fedora]$ . env/bin/activate
         (env) [fedora]$ python ...
   logo: prompt


### PR DESCRIPTION
In Python 3.6, pyvenv is deprecated in favor of python3 -m venv (see https://docs.python.org/3/library/venv.html#module-venv).